### PR TITLE
Fix doc examples raise TypeError

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -103,17 +103,17 @@ The RtMidi library can be compiled with support for more than one
 API. You can select API by adding it after the module name, either in
 the environment variable::
 
-    $ export MIDO_BACKEND=.rmidi/LINUX_ALSA
-    $ export MIDO_BACKEND=.rmidi/LINUX_JACK
+    $ export MIDO_BACKEND=mido.backends.rtmidi/LINUX_ALSA
+    $ export MIDO_BACKEND=mido.backends.rtmidi/UNIX_JACK
 
 or in one of these::
 
-    >>> mido.set_backend('.rtmidi/LINUX_ALSA')
+    >>> mido.set_backend('mido.backends.rtmidi/LINUX_ALSA')
     >>> mido.backend
     <backend mido.backends.rtmidi/LINUX_ALSA (not loaded)>
 
-    >>> mido.Backend('.rtmidi/LINUX_JACK')
-    <backend mido.backends.rtmidi/LINUX_JACK (not loaded)>
+    >>> mido.Backend('mido.backends.rtmidi/UNIX_JACK')
+    <backend mido.backends.rtmidi/UNIX_JACK (not loaded)>
 
 This allows you to, for example, use both ALSA and JACK ports in the
 same program.


### PR DESCRIPTION
Unfortunately, the documentation seems to be misleading. I always have to use the full module string in order to create a backend:

```python
In [29]: mido.Backend('.rtmidi/LINUX_ALSA', load=True)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-29-c3b90ba4eee0> in <module>()
----> 1 mido.Backend('.rtmidi/LINUX_ALSA', load=True)

/tmp/temp/local/lib/python2.7/site-packages/mido-1.1.13-py2.7.egg/mido/backends/backend.pyc in __init__(self, name, api, load, use_environ)
     51 
     52         if load:
---> 53             self.load()
     54 
     55     @property

/tmp/temp/local/lib/python2.7/site-packages/mido-1.1.13-py2.7.egg/mido/backends/backend.pyc in load(self)
     77         property."""
     78         if not self.loaded:
---> 79             self._module = _import_module(self.name)
     80 
     81     def _env(self, name):

/tmp/temp/local/lib/python2.7/site-packages/mido-1.1.13-py2.7.egg/mido/backends/backend.pyc in _import_module(name)
     23 
     24     try:
---> 25         return importlib.import_module(module, package)
     26     except ImportError:
     27         raise ImportError('No module named {}'.format(name))

/usr/lib/python2.7/importlib/__init__.pyc in import_module(name, package)
     28     if name.startswith('.'):
     29         if not package:
---> 30             raise TypeError("relative imports require the 'package' argument")
     31         level = 0
     32         for character in name:

TypeError: relative imports require the 'package' argument

In [30]: mido.Backend('mido.backends.rtmidi/LINUX_ALSA', load=True)
Out[30]: <backend mido.backends.rtmidi/LINUX_ALSA (loaded)>
```