### PR TITLE
Added the ability to read and write file objects as well as filenames

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,10 +4,20 @@ Changes
 Release History
 ---------------
 
+1.1.15 (2015-08-16)
+^^^^^^^^^^^^^^^^^^^
+* Added the ability to use file objects as well as filenames when reading,
+  writing and saving MIDI files. This allows you to create a MIDI file
+  dynamically, save it to an io.BytesIO, and then play that in-memory
+  file, without having to create an intermediate external file. Of course the
+  file (and/or the MidiFile) can still be saved to an external file.
+
+  (Implemented by Brian O'Neill.)
+
 1.1.14 (2015-06-09)
 ^^^^^^^^^^^^^^^^^^^
 
-* bugfix: merge_tracks() concatinated the tracks instead of merging
+* bugfix: merge_tracks() concatenated the tracks instead of merging
   them.  This caused tracks to be played back one by one. (Issue #28,
   reported by Charles Gillingham.)
 

--- a/docs/midi_files.rst
+++ b/docs/midi_files.rst
@@ -2,7 +2,7 @@ MIDI Files
 ==========
 
 MidiFile objects can be used to read, write and play back MIDI
-files. (Writing is not yet implemented.)
+files.
 
 
 Opening a File
@@ -74,14 +74,15 @@ You can create a new file by calling MidiFile without the ``filename``
 argument. The file can then be saved by calling the ``save()`` method::
 
     from mido.midifies import MidiTrack
+    from mido.messages import Messages
 
     with MidiFile() as mid:
         track = MidiTrack()
-        tracks.append(track)
+        mid.tracks.append(track)
 
-        tracks.append(midi.Message('program_change', program=12, time=0))
-        tracks.append(midi.Message('note_on', note=64, velocity=64, time=32)
-        tracks.append(midi.Message('note_off', note=64, velocity=127, time=32)
+        track.append(Message('program_change', program=12, time=0))
+        track.append(Message('note_on', note=64, velocity=64, time=32)
+        track.append(Message('note_off', note=64, velocity=127, time=32)
 
         mid.save('new_song.mid')
 
@@ -95,6 +96,12 @@ If there is no 'end_of_track' message at the end of a track, one will
 be written anyway.
 
 A complete example can be found in ``examples/midifiles/``.
+
+The ``save`` method takes either a filename (``str``) or a file object
+such as an in-memory binary file (an ``io.BytesIO``). If you pass a file
+object, ``save`` does not close it. Similarly, if you pass a file object
+to ``MidiFile`` as a context manager, the file is not closed when the
+the context manager exits.
 
 
 File Types

--- a/docs/midi_files.rst
+++ b/docs/midi_files.rst
@@ -97,11 +97,14 @@ be written anyway.
 
 A complete example can be found in ``examples/midifiles/``.
 
-The ``save`` method takes either a filename (``str``) or a file object
-such as an in-memory binary file (an ``io.BytesIO``). If you pass a file
-object, ``save`` does not close it. Similarly, if you pass a file object
-to ``MidiFile`` as a context manager, the file is not closed when the
-the context manager exits.
+The ``save`` method takes either a filename (``str``) or, using the ``file``
+keyword parameter, a file object such as an in-memory binary file (an
+``io.BytesIO``). If you pass a file object, ``save`` does not close it.
+Similarly, the ``MidiFile`` constructor can take either a filename, or
+a file object by using the ``file`` keyword parameter. if you pass a file
+object to ``MidiFile`` as a context manager, the file is not closed when
+the context manager exits. Examples can be found in ``test_midifiles2.py``.
+
 
 
 File Types

--- a/mido/__init__.py
+++ b/mido/__init__.py
@@ -103,7 +103,7 @@ __author__ = 'Ole Martin Bjorndalen'
 __email__ = 'ombdalen@gmail.com'
 __url__ = 'http://mido.readthedocs.org/'
 __license__ = 'MIT'
-__version__ = '1.1.14'
+__version__ = '1.1.15'
 
 # Prevent splat import.
 __all__ = []

--- a/mido/messages.py
+++ b/mido/messages.py
@@ -148,7 +148,7 @@ def check_channel(channel):
     """Check type and value of channel.
 
     Raises TypeError if the value is not an integer, and ValueError if
-    it is outside range 0..127.
+    it is outside range 0..15.
     """
     if not isinstance(channel, int):
         raise TypeError('channel must be an integer')
@@ -268,7 +268,7 @@ class BaseMessage(object):
     def copy(self, **overrides):
         """Return a copy of the message.
 
-        Attributes will be overriden by the passed keyword arguments.
+        Attributes will be overridden by the passed keyword arguments.
         Only message specific attributes can be overridden. The message
         type can not be changed.
 
@@ -286,7 +286,7 @@ class BaseMessage(object):
         for name, value in overrides.items():
             try:
                 # setattr() is responsible for checking the
-                # name and type of the atrribute.
+                # name and type of the attribute.
                 setattr(message, name, value)
             except AttributeError as err:
                 raise ValueError(*err.args)
@@ -386,7 +386,7 @@ class Message(BaseMessage):
                 '{} message has no attribute {}'.format(self.type, name))
 
     def __delattr__(self, name):
-        raise AttributeError('attribute can not be deleted')
+        raise AttributeError('attribute cannot be deleted')
 
     def bytes(self):
         """Encode message and return as a list of integers."""

--- a/mido/midifiles.py
+++ b/mido/midifiles.py
@@ -208,9 +208,14 @@ def merge_tracks(tracks):
 
 
 class MidiFile:
-    def __init__(self, filename_or_file=None, type=1,
-                 ticks_per_beat=DEFAULT_TICKS_PER_BEAT,
+    def __init__(self, filename=None, file=None,
+                 type=1, ticks_per_beat=DEFAULT_TICKS_PER_BEAT,
                  charset='latin1'):
+
+        assert filename is None or isinstance(filename, str)
+        assert file is None or isinstance(file, io.BufferedIOBase)
+
+        filename_or_file = filename or file     # filename takes precedence
         self.filename_or_file = filename_or_file
         self.tracks = []
         self.charset = charset
@@ -433,21 +438,27 @@ class MidiFile:
         else:
             return False
 
-    def save(self, filename_or_file=None):
-        """Save to a file.
+    def save(self, filename=None, file=None):
+        """Save to a file, given by filename (str) or file (file object),
+        or by filename or file already passed to constructor.
 
-        If filename_or_file is passed, self.filename_or_file will be set to this
-        value, and the data will be saved to this file. Otherwise
-        self.filename_or_file is used.
+        If filename or file is passed, self.filename_or_file will be set to
+        filename if given, else file if given, and the data will be saved to
+        the specified file. Otherwise the existing self.filename_or_file is
+        used (raising ValueError if that too is None).
 
-        Raises ValueError both filename_or_file and self.filename_or_file are None,
+        Raises ValueError if both filename_or_file and self.filename_or_file are None,
         or if a type 0 file has != one track.
         """
         if self.type == 0 and len(self.tracks) != 1:
-            raise ValueError('type 1 file must have exactly 1 track')
+            raise ValueError('type 0 file must have exactly 1 track')
 
+        assert filename is None or isinstance(filename, str)
+        assert file is None or isinstance(file, io.BufferedIOBase)
+
+        filename_or_file = filename or file     # filename takes precedence
         if filename_or_file is self.filename_or_file is None:
-            raise ValueError('no file name')
+            raise ValueError('no file name or file')
 
         if filename_or_file is not None:
             self.filename_or_file = filename_or_file

--- a/mido/test_midifiles2.py
+++ b/mido/test_midifiles2.py
@@ -37,7 +37,7 @@ class TestMidiFileIO(TestCase):
             track.append(Message('note_off', note=64, velocity=127, time=128))
 
             # midi.save('new_song.mid')
-            midi.save(cls.bio)
+            midi.save(file=cls.bio)
 
     def test_midifile_to_bytesIO(self):
         """Compare bio to expected value.
@@ -49,7 +49,7 @@ class TestMidiFileIO(TestCase):
         """Create MidiFile from `self.bio`; temporarily trap stdout and call `print_tracks()`;
         compare what was printed to expected value.
         """
-        midifile = MidiFile(self.bio)
+        midifile = MidiFile(file=self.bio)
 
         _stdout = sys.stdout
         sio= io.StringIO()
@@ -65,7 +65,7 @@ class TestMidiFileIO(TestCase):
         Also check that writes to, reads from external file close file when
         use of them is finished.
         """
-        midifile = MidiFile(self.bio)
+        midifile = MidiFile(file=self.bio)
 
         # Get a temp file name, don't leave the file open,
         # but don't delete it either, just to reserve the name.
@@ -80,7 +80,7 @@ class TestMidiFileIO(TestCase):
         # read midifile back in to another BytesIO
         bio2 = io.BytesIO()
         with MidiFile(tempfilename) as midi2:   # closes it again
-            midi2.save(bio2)
+            midi2.save(file=bio2)
         self.assertFalse(bio2.closed)
         self.assertTrue(named_tempfile.file.closed)
 

--- a/mido/test_midifiles2.py
+++ b/mido/test_midifiles2.py
@@ -1,0 +1,90 @@
+__author__ = 'brianoneill'
+
+from unittest import TestCase
+
+import mido
+from mido.messages import Message
+from mido.midifiles import MidiFile, MidiTrack
+
+import io
+import tempfile
+import os
+import sys
+
+
+class TestMidiFileIO(TestCase):
+    bio = io.BytesIO()    # will contain a midifile
+    expected_bio = b'MThd\x00\x00\x00\x06\x00\x01\x00\x01\x01\xe0' \
+                   b'MTrk\x00\x00\x00\x10\x00\xc0\x0c \x90@@\x81\x00\x80@\x7f\x00\xff/\x00'
+    expected_sio = '''\
+=== Track 0
+<message program_change channel=0 program=12 time=0>
+<message note_on channel=0 note=64 velocity=64 time=32>
+<message note_off channel=0 note=64 velocity=127 time=128>
+<meta message end_of_track time=0>
+'''
+
+    @classmethod
+    def setUpClass(cls):
+        """Create new/empty MidiFile, populate it, save to `cls.bio`.
+        """
+        with MidiFile() as midi:
+            track = MidiTrack()
+            midi.tracks.append(track)
+
+            track.append(Message('program_change', program=12, time=0))
+            track.append(Message('note_on', note=64, velocity=64, time=32))
+            track.append(Message('note_off', note=64, velocity=127, time=128))
+
+            # midi.save('new_song.mid')
+            midi.save(cls.bio)
+
+    def test_midifile_to_bytesIO(self):
+        """Compare bio to expected value.
+        """
+        self.assertFalse(self.bio.closed)
+        self.assertEqual(self.bio.getvalue(), self.expected_bio)
+
+    def test_midifile_from_bytesIO(self):
+        """Create MidiFile from `self.bio`; temporarily trap stdout and call `print_tracks()`;
+        compare what was printed to expected value.
+        """
+        midifile = MidiFile(self.bio)
+
+        _stdout = sys.stdout
+        sio= io.StringIO()
+        sys.stdout = sio
+        midifile.print_tracks()
+        sys.stdout = _stdout
+
+        self.assertEqual(sio.getvalue(), self.expected_sio)
+
+    def test_midifile_to_from_file(self):
+        """Write MidiFile to external file, read file back in as a MidiFile,
+        `save` it to another BytesIO; compare to `self.bio`.
+        Also check that writes to, reads from external file close file when
+        use of them is finished.
+        """
+        midifile = MidiFile(self.bio)
+
+        # Get a temp file name, don't leave the file open,
+        # but don't delete it either, just to reserve the name.
+        named_tempfile = tempfile.NamedTemporaryFile('wb', delete=False)    # keep after closing
+        tempfilename = named_tempfile.name
+        named_tempfile.close()
+
+        # Write midifile to temp file (name)
+        midifile.save(tempfilename)             # closes named_tempfile
+        self.assertTrue(named_tempfile.file.closed)
+
+        # read midifile back in to another BytesIO
+        bio2 = io.BytesIO()
+        with MidiFile(tempfilename) as midi2:   # closes it again
+            midi2.save(bio2)
+        self.assertFalse(bio2.closed)
+        self.assertTrue(named_tempfile.file.closed)
+
+        os.remove(named_tempfile.name)          # cleanup temp file
+
+        # compare midifile(s)
+        self.assertEqual(self.bio.getvalue(), bio2.getvalue())


### PR DESCRIPTION
Added the ability to use file objects as well as filenames when reading, writing and saving MIDI files. This allows you to create a MIDI file dynamically (possibly *not* using `mido`), save it to an `io.BytesIO`, and then play that in-memory file, without having to create an intermediate external file. Of course the file (and/or the MidiFile) can still be saved to an external file.

midifiles.py: changes to ByteReader, ByteWriter, MidiFile.save. Parameters and instance attribute `filename` renamed to `filename_or_file`.
test_midifiles2.py: unittests of new feature
messages.py: corrected docstrings, error messages
__init__.py: version number bump

Docs: midi_files.rst -- corrected an example; added a paragraph (which could be better-placed) on new feature