### PR TITLE
Added descriptive Host Error messages to PortMidi backend

### DIFF
--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -13,6 +13,7 @@ from ..parser import Parser
 from ..messages import Message
 from ..ports import BaseInput, BaseOutput, sleep
 from . import portmidi_init as pm
+from ctypes import create_string_buffer
 
 _state = {'port_count': 0}
 
@@ -31,6 +32,10 @@ def _check_error(return_value):
     The exception will be raised with the error message from PortMidi.
     """
     if return_value < 0:
+        if return_value == pm.pmHostError:
+            buf = create_string_buffer(80)
+            pm.lib.Pm_GetHostErrorText(buf,80)
+            raise IOError(buf.raw.decode().rstrip('\0'))
         raise IOError(pm.lib.Pm_GetErrorText(return_value))
     
     

--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -35,7 +35,7 @@ def _check_error(return_value):
         if return_value == pm.pmHostError:
             buf = create_string_buffer(80)
             pm.lib.Pm_GetHostErrorText(buf,80)
-            raise IOError(buf.raw.decode().rstrip('\0'))
+            raise IOError("Host Error: " + buf.raw.decode().rstrip('\0'))
         raise IOError(pm.lib.Pm_GetErrorText(return_value))
     
     


### PR DESCRIPTION
In the case of a PortMidi host error, uses PmGetHostErrorText, instead of just PmGetErrorText. There might be a better way to deal with functions asking for buffers using ctypes, but I need a solution quickly so I just did it straight up.