### PR TITLE
Fix sending long sysex messages with rtmidi backend

### DIFF
--- a/mido/backends/rtmidi.py
+++ b/mido/backends/rtmidi.py
@@ -9,6 +9,9 @@ import time
 import rtmidi
 from ..ports import BaseInput, BaseOutput
 
+MSG_LEN = 64
+SLEEP_TIME = 0.02
+
 def _get_api_lookup():
     api_to_name = {}
     name_to_api = {}
@@ -138,4 +141,12 @@ class Input(PortCommon, BaseInput):
 
 class Output(PortCommon, BaseOutput):
     def _send(self, message):
-        self._rt.send_message(message.bytes())
+        if message.type == 'sysex':
+            t = message.bytes()
+            while len(t) > MSG_LEN:
+                h, t = t[:MSG_LEN], t[MSG_LEN:]
+                self._rt.send_message(h)
+                time.sleep(SLEEP_TIME)
+            self._rt.send_message(t)
+        else:
+            self._rt.send_message(message.bytes())


### PR DESCRIPTION
There is a problem (ALSA: seq_midi: MIDI output buffer overrun) when sending very large sysex messages. However, I found a solution and a workaround when working with the rtmidi backend.

The solution is based on [a python-rtmidi example](https://github.com/SpotlightKid/python-rtmidi/blob/master/examples/sendsysex.py). Basically, if the message is too large it must be splitted and the application must wait for the buffer to be empty before sending more data, otherwise the MIDI output buffer overrun occurs.
