### PR TITLE
Don't construct MidiTrack when index is provided

### DIFF
--- a/mido/midifiles.py
+++ b/mido/midifiles.py
@@ -153,10 +153,15 @@ class MidiTrack(list):
             self.insert(0, MetaMessage('track_name', name=name, time=0))
 
     def __getitem__(self, index_or_slice):
-        # Return a MidiTrack instead of a list.
-        # Todo: this make a copy of the list. Is there a better way?
+        # Retrieve item from the MidiTrack
         lst = list.__getitem__(self, index_or_slice)
-        return self.__class__(lst)
+        # If an index was provided, return the list element
+        if isinstance(index_or_slice, int):
+            return lst
+        # Otherwise, construct a MidiTrack to return.
+        # Todo: this make a copy of the list. Is there a better way?
+        else:
+            return self.__class__(lst)
 
     def __repr__(self):
         return '<midi track {!r} {} messages>'.format(self.name, len(self))


### PR DESCRIPTION
It appears that you can only slice `MidiTrack` instances; indexing doesn't work:

```
In [1]: import mido

In [2]: t = mido.MidiTrack()

In [3]: t.append(mido.Message('note_on'))

In [4]: t[0]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-d0a24a012877> in <module>()
----> 1 t[0]

/usr/local/lib/python2.7/site-packages/mido-1.1.15-py2.7.egg/mido/midifiles.pyc in __getitem__(self, index_or_slice)
    157         # Todo: this make a copy of the list. Is there a better way?
    158         lst = list.__getitem__(self, index_or_slice)
--> 159         return self.__class__(lst)
    160
    161     def __repr__(self):

TypeError: 'Message' object is not iterable

In [5]: t[0:]
Out[5]: [<message note_on channel=0 note=0 velocity=64 time=0>]
```

It is trying to construct a `MidiTrack` where the initializer is just a single `Message`, which fails because the `Message` is not iterable.  I would expect it to return `mido.Message('note_on')` when indexing, not a `MidiTrack`, so I don't even think trying to construct a `MidiTrack` is the right thing when an index is provided.

This pull request solves this issue by simply returning the indexed element from the `MidiTrack` when an index (int) is provided.