### PR TITLE
Added error mode option to MidiFile as discussed in issue #63.

### DIFF
--- a/mido/__init__.py
+++ b/mido/__init__.py
@@ -66,7 +66,7 @@ from .messages import Message
 from .messages import parse_string, parse_string_stream, format_as_string
 from .frozen import FrozenMessage, FrozenMetaMessage, freeze
 from .parser import Parser, parse, parse_all
-from .midifiles import MidiFile, MidiTrack, merge_tracks
+from .midifiles import MidiFile, MidiFileError, MidiTrack, merge_tracks
 from .midifiles import MetaMessage, bpm2tempo, tempo2bpm
 from .syx import read_syx_file, write_syx_file
 

--- a/mido/midifiles/__init__.py
+++ b/mido/midifiles/__init__.py
@@ -1,3 +1,3 @@
 from .meta import bpm2tempo, tempo2bpm, MetaMessage
 from .tracks import MidiTrack, merge_tracks
-from .midifiles import MidiFile
+from .midifiles import MidiFile, MidiFileError


### PR DESCRIPTION
This passes an `error_mode` variable around in `read_track()`, `read_message()` etc.
