### PR TITLE
README.rst: fix usage of the "with" statement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ designed to be as straight forward and Pythonic as possible:
 
 .. code-block:: python
 
-    >>> with input as mido.open_input('SH-201'):
-    ...     for msg in input:
+    >>> with mido.open_input('SH-201') as midi_input:
+    ...     for msg in midi_input:
     ...         print(msg)
 
 .. code-block:: python


### PR DESCRIPTION
Fix the usage of the "with" python statement in one of the examples.

While at it also rename the "input" variable to "midi_input", to avoid having
a variable using the same name of a keyword of the language.
