### PR TITLE
added missing init of base class for SocketPort

### DIFF
--- a/mido/sockets.py
+++ b/mido/sockets.py
@@ -77,7 +77,7 @@ class PortServer(MultiPort):
 
 class SocketPort(BaseIOPort):
     def __init__(self, host, portno, conn=None):
-        self.name = format_address(host, portno)
+        BaseIOPort.__init__(self, name=format_address(host, portno))
         self.closed = False
         self._parser = Parser()
         self._messages = self._parser.messages


### PR DESCRIPTION
The class SocketPort neglected to call the super class ```__init__``` method.  This resulted in ```AttributeError: 'SocketPort' object has no attribute '_lock'``` errors.  Simply adding the call allows the class work correctly.