### PR TITLE
Duck-Type style time checking for Numpy ints

### DIFF
--- a/mido/messages.py
+++ b/mido/messages.py
@@ -133,14 +133,16 @@ def get_spec(type_or_status_byte):
 
 
 def check_time(time):
-    """Check type and value of time.
-    
-    Raises TypeError if value is not an integer or a float
-    """
-    if PY2 and isinstance(time, long):
-        return
-
-    if not (isinstance(time, int) or isinstance(time, float)):
+    valid = True
+    try:
+        int(time)
+    except:
+        valid = False
+    try:
+        float(time)
+    except:
+        valid = False
+    if not valid:
         raise TypeError('time must be an integer or float')
 
 

--- a/mido/messages.py
+++ b/mido/messages.py
@@ -5,6 +5,7 @@ There is no need to use this module directly. All you need is
 available in the top level module.
 """
 import sys
+import numbers
 
 PY2 = (sys.version_info.major == 2)
 
@@ -19,7 +20,7 @@ MAX_SONGPOS = 16383
 class MessageSpec(object):
     """
     Specifications for creating a message.
-    
+
     status_byte is the first byte of the message. For channel
     messages, the channel (lower 4 bits) is clear.
 
@@ -42,7 +43,7 @@ class MessageSpec(object):
         self.type = type_
         self.arguments = arguments
         self.length = length
-   
+
         # Attributes that can be set on the object
         self.settable_attributes = set(self.arguments) | {'time'}
 
@@ -133,18 +134,11 @@ def get_spec(type_or_status_byte):
 
 
 def check_time(time):
-    valid = True
-    try:
-        int(time)
-    except:
-        valid = False
-    try:
-        float(time)
-    except:
-        valid = False
-    if not valid:
-        raise TypeError('time must be an integer or float')
+    if PY2 and isinstance(time, long):
+        return
 
+    if not isinstance(value, numbers.Number):
+        raise TypeError('time must be an integer or float')
 
 def check_channel(channel):
     """Check type and value of channel.
@@ -250,7 +244,7 @@ def encode_data(data):
     """
     return list(data) + [0xf7]
 
- 
+
 def encode_pitch(pitch):
     """Encode pitchwheel pitch as a list of bytes."""
     pitch -= MIN_PITCHWHEEL
@@ -623,5 +617,5 @@ def format_as_string(message, include_time=True):
             value = str(value)
             value = value.replace('L', '')
         words.append('{}={}'.format(name, value))
-    
+
     return ' '.join(words)

--- a/mido/midifiles/meta.py
+++ b/mido/midifiles/meta.py
@@ -14,6 +14,7 @@ from __future__ import print_function, division
 import sys
 import math
 import struct
+import numbers
 from contextlib import contextmanager
 from ..messages import BaseMessage, check_time
 
@@ -100,7 +101,7 @@ def encode_variable_int(value):
     This is used for delta times and meta message payload
     length.
     """
-    if not isinstance(value, int) or value < 0:
+    if not isinstance(value, numbers.Integral) or value < 0:
         raise ValueError('variable int must be a positive integer')
 
     bytes = []
@@ -128,7 +129,7 @@ def bpm2tempo(bpm):
     """Convert beats per minute to MIDI file tempo.
 
     Returns microseconds per beat as an integer::
-    
+
         240 => 250000
         120 => 500000
         60 => 1000000
@@ -188,7 +189,7 @@ class MetaSpec_sequence_number(MetaSpec):
 
     def check(self, name, value):
         check_int(value, 0, 255)
-            
+
 class MetaSpec_text(MetaSpec):
     type_byte = 0x01
     attributes = ['text']
@@ -210,7 +211,7 @@ class MetaSpec_track_name(MetaSpec_text):
     type_byte = 0x03
     attributes = ['name']
     defaults = ['']
-    
+
     def decode(self, message, data):
         message.name = decode_string(data)
 
@@ -245,7 +246,7 @@ class MetaSpec_channel_prefix(MetaSpec):
 
     def check(self, name, value):
         check_int(value, 0, 0xff)
-            
+
 
 class MetaSpec_midi_port(MetaSpec):
     type_byte = 0x21
@@ -405,7 +406,7 @@ def add_meta_spec(klass):
     spec.settable_attributes = set(spec.attributes) | {'time'}
     _specs[spec.type_byte] = spec
     _specs[spec.type] = spec
-    
+
 def _add_builtin_meta_specs():
     for name in globals():
         if name.startswith('MetaSpec_'):
@@ -470,7 +471,7 @@ class MetaMessage(BaseMessage):
         return ([0xff, self._spec.type_byte]
                 + encode_variable_int(len(data))
                 + data)
-    
+
     def __repr__(self):
         attributes = []
         for name in self._spec.attributes:


### PR DESCRIPTION
Referring to https://github.com/craffel/pretty-midi/issues/114

Numpy ints cannot be properly checked with `isinstance(value, int)` in Python 3.