### PR TITLE
Fix dll name for darwin platform

### DIFF
--- a/mido/backends/portmidi_init.py
+++ b/mido/backends/portmidi_init.py
@@ -11,7 +11,7 @@ import ctypes.util
 
 dll_name = ''
 if sys.platform == 'darwin':
-    dll_namex = ctypes.util.find_library('libportmidi.dylib')
+    dll_name = ctypes.util.find_library('libportmidi.dylib')
 elif sys.platform in ('win32', 'cygwin'):
     dll_name = 'portmidi.dll'
 else:


### PR DESCRIPTION
Hi,
I noticed there was a discrepancy in the dll_name variable for Darwin platform which prevented mido to load the portmidi dynamic library properly on OS X and made all my mido-based examples crash. 
