### PR TITLE
Prevent trying to read extremely long messages

### DIFF
--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -34,6 +34,9 @@ from .units import tick2second
 DEFAULT_TEMPO = 500000
 DEFAULT_TICKS_PER_BEAT = 480
 
+# Maximum message length to attempt to read.
+MAX_MESSAGE_LENGTH = 1000000
+
 def print_byte(byte, pos=0):
     char = chr(byte)
     if char.isspace() or not char in string.printable:
@@ -72,6 +75,9 @@ def read_byte(self):
 
 
 def read_bytes(infile, size):
+    if size > MAX_MESSAGE_LENGTH:
+        raise IOError('Message length {} exceeds maximum length {}'.format(
+            size, MAX_MESSAGE_LENGTH))
     return [read_byte(infile) for _ in range(size)]
 
 

--- a/mido/midifiles/test_midifiles.py
+++ b/mido/midifiles/test_midifiles.py
@@ -42,6 +42,15 @@ def test_single_message():
     """).tracks[0] == [Message('note_on', note=64, velocity=64, time=32)]
 
 
+def test_too_long_message():
+    with raises(IOError):
+      read_file(HEADER_ONE_TRACK + """
+      4d 54 72 6b  # MTrk
+      00 00 00 04
+      00 ff 03 ff ff 7f # extremely long track name message
+      """)
+
+
 def test_two_tracks():
     mid = read_file("""
     4d54 6864 0000 0006 0001 0002 0040        # Header


### PR DESCRIPTION
This prevents a problem I had while trying to read a (presumably corrupt) midi file that claimed to have a message with length 34359738240. Before this patch, python crashed after trying to allocate too much memory. After this patch, I can cleanly catch the IOError exception.