### PR TITLE
Add missing python-rtmidi dependency to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
                'bin/mido-serve',
                'bin/mido-connect'],
     include_package_data=True,
-    install_requires=[],
+    install_requires=['python-rtmidi'],
     license='MIT',
     zip_safe=False,
     classifiers=(


### PR DESCRIPTION
This closes https://github.com/olemb/mido/issues/96