### PR TITLE
Fix portmidi backend

### DIFF
--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -109,7 +109,7 @@ class PortCommon(object):
             device = _get_default_device(self.is_input)
             self.name = device['name']
         else:
-            device = _get_named_device(self.name, self.is_output)
+            device = _get_named_device(self.name, self.is_input)
 
         if device['opened']:
             if self.is_input:

--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -72,10 +72,10 @@ def _get_named_device(name, get_input):
 
         # Skip if device is the wrong type
         if get_input:
-            if device['is_output']:
+            if not device['is_input']:
                 continue
         else:
-            if device['is_input']:
+            if not device['is_output']:
                 continue
 
         if device['opened']:


### PR DESCRIPTION
Hello,

There's an issue on the port selection code of the PortMidi backend which is solved by the first commit of this PR.

The second commit changes the logic for selecting ports of _get_name_device. Give that each device has two properties (is_input, is_output), I believe the presented is much saner way of doing said selection.