### PR TITLE
Allow reading files with out-of-spec sysex and pitchwheel messages

### DIFF
--- a/mido/messages/checks.py
+++ b/mido/messages/checks.py
@@ -3,6 +3,12 @@ from .specs import (SPEC_BY_TYPE, MIN_SONGPOS, MAX_SONGPOS,
                     MIN_PITCHWHEEL, MAX_PITCHWHEEL)
 from ..py2 import convert_py2_bytes
 
+
+# If set to False, sysex bytes must be in the range 0..127.
+# If set to True, sysex bytes must by in the range 0..255.
+ALLOW_SYSEX_LARGE_BYTES = False
+
+
 def check_type(type_):
     if type_ not in SPEC_BY_TYPE:
         raise ValueError('invalid message type {!r}'.format(type_))
@@ -53,8 +59,13 @@ def check_frame_value(value):
 def check_data_byte(value):
     if not isinstance(value, Integral):
         raise TypeError('data byte must be int')
-    elif not 0 <= value <= 127:
-        raise ValueError('data byte must be in range 0..127')
+    elif ALLOW_SYSEX_LARGE_BYTES and not 0 <= value <= 255:
+        raise ValueError('data byte must be in range 0..255')
+    elif not ALLOW_SYSEX_LARGE_BYTES and not 0 <= value <= 127:
+        raise ValueError(
+            'data byte must be in range 0..127. If this is intentional, you '
+            'may override this check by setting '
+            'mido.messages.checks.ALLOW_SYSEX_LARGE_BYTES to True')
 
 
 def check_time(time):
@@ -67,7 +78,6 @@ _CHECKS = {
     'data': check_data,
     'channel': check_channel,
     'control': check_data_byte,
-    'data': check_data,
     'frame_type': check_frame_type,
     'frame_value': check_frame_value,
     'note': check_data_byte,

--- a/mido/messages/checks.py
+++ b/mido/messages/checks.py
@@ -1,13 +1,19 @@
 from numbers import Integral, Real
 from .specs import (SPEC_BY_TYPE, MIN_SONGPOS, MAX_SONGPOS,
-                    MIN_PITCHWHEEL, MAX_PITCHWHEEL)
+                    MIN_PITCHWHEEL, MAX_PITCHWHEEL,
+                    MIN_PITCHWHEEL_LARGE, MAX_PITCHWHEEL_LARGE)
 from ..py2 import convert_py2_bytes
 
 
-# If set to False, sysex bytes must be in the range 0..127.
-# If set to True, sysex bytes must by in the range 0..255.
-ALLOW_SYSEX_LARGE_BYTES = False
+# If set to False, data bytes must be in the range 0..127.
+# If set to True, data bytes must by in the range 0..255.
+ALLOW_DATA_LARGE_BYTES = False
 
+# If set to to False, pitch wheel range must be between MIN_PITCHWHEEL and
+# MAX_PITCHWHEEL
+# If set to to True, pitch wheel range must be between MIN_PITCHWHEEL_LARGE and
+# MAX_PITCHWHEEL_LARGE
+ALLOW_LARGE_PITCHWHEEL_RANGE = False
 
 def check_type(type_):
     if type_ not in SPEC_BY_TYPE:
@@ -31,9 +37,18 @@ def check_pos(pos):
 
 def check_pitch(pitch):
     if not isinstance(pitch, Integral):
-        raise TypeError('pichwheel value must be int')
-    elif not MIN_PITCHWHEEL <= pitch <= MAX_PITCHWHEEL:
+        raise TypeError('pitchwheel value must be int')
+    elif ALLOW_LARGE_PITCHWHEEL_RANGE and (
+        not MIN_PITCHWHEEL_LARGE <= pitch <= MAX_PITCHWHEEL_LARGE):
         raise ValueError('pitchwheel value must be in range {}..{}'.format(
+                         MIN_PITCHWHEEL_LARGE, MAX_PITCHWHEEL_LARGE))
+    elif not ALLOW_LARGE_PITCHWHEEL_RANGE and (
+        not MIN_PITCHWHEEL <= pitch <= MAX_PITCHWHEEL):
+        raise ValueError(
+            'pitchwheel value must be in range {}..{}. Other values violate '
+            'the MIDI spec. However, if this is intentional, you may override '
+            'this check by setting '
+            'mido.messages.checks.ALLOW_LARGE_PITCHWHEEL_RANGE to True.'.format(
                          MIN_PITCHWHEEL, MAX_PITCHWHEEL))
 
 
@@ -59,13 +74,14 @@ def check_frame_value(value):
 def check_data_byte(value):
     if not isinstance(value, Integral):
         raise TypeError('data byte must be int')
-    elif ALLOW_SYSEX_LARGE_BYTES and not 0 <= value <= 255:
+    elif ALLOW_DATA_LARGE_BYTES and not 0 <= value <= 255:
         raise ValueError('data byte must be in range 0..255')
-    elif not ALLOW_SYSEX_LARGE_BYTES and not 0 <= value <= 127:
+    elif not ALLOW_DATA_LARGE_BYTES and not 0 <= value <= 127:
         raise ValueError(
-            'data byte must be in range 0..127. If this is intentional, you '
-            'may override this check by setting '
-            'mido.messages.checks.ALLOW_SYSEX_LARGE_BYTES to True')
+            'data byte must be in range 0..127. Values > 127 violate the MIDI '
+            'spec. However, if this is intentional, you may override this '
+            'check by setting mido.messages.checks.ALLOW_DATA_LARGE_BYTES to '
+            'True.')
 
 
 def check_time(time):

--- a/mido/messages/specs.py
+++ b/mido/messages/specs.py
@@ -17,6 +17,11 @@ SYSEX_END = 0xf7
 MIN_PITCHWHEEL = -8192
 MAX_PITCHWHEEL = 8191
 
+# Pitchwheel range when stored by a non-compliant device using a 16 bit signed
+# integer
+MIN_PITCHWHEEL_LARGE = -32768
+MAX_PITCHWHEEL_LARGE = 32767
+
 # Song pos is a 14 bit unsigned integer
 MIN_SONGPOS = 0
 MAX_SONGPOS = 16383

--- a/mido/messages/test_checks.py
+++ b/mido/messages/test_checks.py
@@ -1,5 +1,6 @@
 from pytest import raises
-from .checks import check_time
+from .checks import check_time, check_data
+from ..messages import checks
 from ..py2 import PY2
 
 
@@ -23,3 +24,17 @@ def test_check_time():
 
     with raises(TypeError):
         check_time('abc')
+
+def test_check_data():
+    check_data(b'\x00\x7f')
+
+    with raises(ValueError):
+      check_data(b'\x80')
+
+    with raises(ValueError):
+      check_data(b'\xff')
+
+    checks.ALLOW_SYSEX_LARGE_BYTES = True
+    check_data(b'\x80')
+    check_data(b'\xff')
+    checks.ALLOW_SYSEX_LARGE_BYTES = False

--- a/mido/messages/test_checks.py
+++ b/mido/messages/test_checks.py
@@ -1,5 +1,5 @@
 from pytest import raises
-from .checks import check_time, check_data
+from .checks import check_time, check_data, check_pitch
 from ..messages import checks
 from ..py2 import PY2
 
@@ -34,7 +34,22 @@ def test_check_data():
     with raises(ValueError):
       check_data(b'\xff')
 
-    checks.ALLOW_SYSEX_LARGE_BYTES = True
+    checks.ALLOW_DATA_LARGE_BYTES = True
     check_data(b'\x80')
     check_data(b'\xff')
-    checks.ALLOW_SYSEX_LARGE_BYTES = False
+    checks.ALLOW_DATA_LARGE_BYTES = False
+
+def test_check_pitchwheel():
+    check_pitch(0)
+    check_pitch(8191)
+
+    with raises(ValueError):
+      check_pitch(8192)
+
+    with raises(ValueError):
+      check_pitch(32768)
+
+    checks.ALLOW_LARGE_PITCHWHEEL_RANGE = True
+    check_pitch(8192)
+    check_pitch(-9000)
+    checks.ALLOW_LARGE_PITCHWHEEL_RANGE = False

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -130,10 +130,6 @@ def read_message(infile, status_byte, peek_data, delta, clip=False):
 
     if clip:
         data_bytes = [byte if byte < 127 else 127 for byte in data_bytes]
-    else:
-        for byte in data_bytes:
-            if byte > 127:
-                raise IOError('data byte must be in range 0..127')
 
     return Message.from_bytes([status_byte] + data_bytes, time=delta)
 

--- a/mido/midifiles/test_midifiles.py
+++ b/mido/midifiles/test_midifiles.py
@@ -76,8 +76,7 @@ def test_eof_in_track():
 
 
 def test_invalid_data_byte_no_clipping():
-    # TODO: should this raise IOError?
-    with raises(IOError):
+    with raises(ValueError):
         read_file(HEADER_ONE_TRACK + """
         4d 54 72 6b  # MTrk
         00 00 00 04  # Chunk size


### PR DESCRIPTION
I need to process some MIDI files that contain messages with out of range values. Normally these should not be parsed, but for special cases, it's useful to be able to override the checks to be more lenient.

This PR adds the ability to enable more lenient checks for sysex data bytes and pitchwheel values.