### PR TITLE
 Re-added import ctypes.byref to fix portmidi backend

### DIFF
--- a/mido/backends/portmidi_init.py
+++ b/mido/backends/portmidi_init.py
@@ -7,7 +7,7 @@ modifications.
 import sys
 from ctypes import (CDLL, CFUNCTYPE, POINTER, Structure, c_char_p,
                     c_int, c_long, c_uint, c_void_p, cast,
-                    create_string_buffer)
+                    create_string_buffer, byref)
 import ctypes.util
 
 dll_name = ''


### PR DESCRIPTION
This was fixed in commit d051be32e4f6ee52f4570bcfed445aae20a92526 but then broken again with codebase cleaning in df6d05a6abcf6139ca31715dd3ed5450b2d98e96