### PR TITLE
Added routine to get total message count from MidiFiles. 

### DIFF
--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -302,7 +302,7 @@ class MidiFile(object):
         self.charset = charset
         self.debug = debug
         self.clip = clip
-        self.tempo = DEFAULT_TEMPO
+
         self.tracks = []
 
         if type not in range(3):
@@ -378,18 +378,19 @@ class MidiFile(object):
         if self.type == 2:
             raise TypeError("can't merge tracks in type 2 (asynchronous) file")
 
+        tempo = DEFAULT_TEMPO
         for msg in merge_tracks(self.tracks):
             # Convert message time from absolute time
             # in ticks to relative time in seconds.
             if msg.time > 0:
-                delta = tick2second(msg.time, self.ticks_per_beat, self.tempo)
+                delta = tick2second(msg.time, self.ticks_per_beat, tempo)
             else:
                 delta = 0
 
             yield msg.copy(time=delta)
 
             if msg.type == 'set_tempo':
-                self.tempo = msg.tempo
+                tempo = msg.tempo
 
     def play(self, meta_messages=False):
         """Play back all tracks.

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -302,7 +302,7 @@ class MidiFile(object):
         self.charset = charset
         self.debug = debug
         self.clip = clip
-
+        self.tempo = DEFAULT_TEMPO
         self.tracks = []
 
         if type not in range(3):
@@ -378,19 +378,18 @@ class MidiFile(object):
         if self.type == 2:
             raise TypeError("can't merge tracks in type 2 (asynchronous) file")
 
-        tempo = DEFAULT_TEMPO
         for msg in merge_tracks(self.tracks):
             # Convert message time from absolute time
             # in ticks to relative time in seconds.
             if msg.time > 0:
-                delta = tick2second(msg.time, self.ticks_per_beat, tempo)
+                delta = tick2second(msg.time, self.ticks_per_beat, self.tempo)
             else:
                 delta = 0
 
             yield msg.copy(time=delta)
 
             if msg.type == 'set_tempo':
-                tempo = msg.tempo
+                self.tempo = msg.tempo
 
     def play(self, meta_messages=False):
         """Play back all tracks.

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -329,7 +329,7 @@ class MidiFile(object):
         return track
 
     def _load(self, infile):
-	    self._msg_count = 0
+        self._msg_count = 0
 	
         if self.debug:
             infile = DebugFileWrapper(infile)

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -328,7 +328,6 @@ class MidiFile(object):
         return track
 
     def _load(self, infile):
-
         if self.debug:
             infile = DebugFileWrapper(infile)
 
@@ -367,7 +366,8 @@ class MidiFile(object):
 
         return sum(msg.time for msg in self)
 
-    def __len__(self):
+    def msg_count(self):
+        """Return total message count of all tracks (inclusive of end of track messages)."""
         return sum(len(track) for track in self.tracks)
 
     def __iter__(self):

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -304,6 +304,7 @@ class MidiFile(object):
         self.clip = clip
 
         self.tracks = []
+		self._msg_count = 0
 
         if type not in range(3):
             raise ValueError(
@@ -328,6 +329,8 @@ class MidiFile(object):
         return track
 
     def _load(self, infile):
+		self._msg_count = 0
+	
         if self.debug:
             infile = DebugFileWrapper(infile)
 
@@ -365,6 +368,13 @@ class MidiFile(object):
                              ' for type 2 (asynchronous) file')
 
         return sum(msg.time for msg in self)
+		
+	def msg_count(self):
+        """Returns the total number of messages present in the MIDI file."""
+        if self._msg_count < 1:
+            for msg in self:
+                self._msg_count += 1
+        return self._msg_count
 
     def __iter__(self):
         # The tracks of type 2 files are not in sync, so they can

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -369,7 +369,7 @@ class MidiFile(object):
 
         return sum(msg.time for msg in self)
 		
-	def msg_count(self):
+    def msg_count(self):
         """Returns the total number of messages present in the MIDI file."""
         if self._msg_count < 1:
             for msg in self:

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -329,7 +329,7 @@ class MidiFile(object):
         return track
 
     def _load(self, infile):
-		self._msg_count = 0
+	    self._msg_count = 0
 	
         if self.debug:
             infile = DebugFileWrapper(infile)

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -304,7 +304,7 @@ class MidiFile(object):
         self.clip = clip
 
         self.tracks = []
-		self._msg_count = 0
+        self._msg_count = 0
 
         if type not in range(3):
             raise ValueError(

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -367,7 +367,9 @@ class MidiFile(object):
         return sum(msg.time for msg in self)
 
     def msg_count(self):
-        """Return total message count of all tracks (inclusive of end of track messages)."""
+        """Return total message count of all tracks.
+
+        Inclusive of end-of-track messages."""
         return sum(len(track) for track in self.tracks)
 
     def __iter__(self):

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -304,7 +304,6 @@ class MidiFile(object):
         self.clip = clip
 
         self.tracks = []
-        self._msg_count = 0
 
         if type not in range(3):
             raise ValueError(
@@ -329,8 +328,7 @@ class MidiFile(object):
         return track
 
     def _load(self, infile):
-        self._msg_count = 0
-	
+
         if self.debug:
             infile = DebugFileWrapper(infile)
 
@@ -368,13 +366,9 @@ class MidiFile(object):
                              ' for type 2 (asynchronous) file')
 
         return sum(msg.time for msg in self)
-		
-    def msg_count(self):
-        """Returns the total number of messages present in the MIDI file."""
-        if self._msg_count < 1:
-            for msg in self:
-                self._msg_count += 1
-        return self._msg_count
+
+    def __len__(self):
+        return sum(len(track) for track in self.tracks)
 
     def __iter__(self):
         # The tracks of type 2 files are not in sync, so they can


### PR DESCRIPTION
I thought it would be nice to be able to get the total message count of a midi file from MidiFile, without having to load the data back into a Parser and parse it all over again.

Useful for creating arrays of static size to manipulate midi data (e.g., with numpy).

Apologies for the gratuitous commits... never use notepad's tabs.